### PR TITLE
Ghost 1.0 Theme migration

### DIFF
--- a/ghost/theme/arabica/post.hbs
+++ b/ghost/theme/arabica/post.hbs
@@ -25,7 +25,7 @@
 
             var disqus_config = function () {
               this.page.url = '{{@blog.url}}{{url}}';  // Replace PAGE_URL with your page's canonical URL variable
-              this.page.identifier = 'ghost-{{id}}';   // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+              this.page.identifier = 'ghost-{{comment_id}}';   // Replace PAGE_IDENTIFIER with your page's unique identifier variable
             };
 
             (function() { // DON'T EDIT BELOW THIS LINE


### PR DESCRIPTION
Replaces 'id' with 'comment_id' for disqus integration